### PR TITLE
Switch to moment.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ attribute.
             wasDate = new Date("Thu Jul 18 2013 15:48:59 GMT+0400");
         return (
           <div>
-            <p>Today is <Timestamp value={now} format="%Y/%m/%d" /></p>
+            <p>Today is <Timestamp value={now} format="YYYY/mm/dd" /></p>
             <p>This was <Timestamp value={wasDate} relative /></p>
           </div>
         );

--- a/index.js
+++ b/index.js
@@ -1,18 +1,7 @@
 "use strict";
 
-var datetime = require('datetime');
+var moment = require('moment');
 var React = require('react');
-
-function leadingZero(n, leading) {
-  return n >= 10 ? n : (leading ? leading : '0')+n;
-}
-
-function formatOffset(d) {
-  var offset = d.getTimezoneOffset();
-  var hour = leadingZero(Math.round(Math.abs(offset / 60)));
-  var min = leadingZero(offset % 60);
-  return (offset > 0 ? '-' : '+') + hour + ':' + min;
-}
 
 var Time = React.createClass({
 
@@ -25,10 +14,9 @@ var Time = React.createClass({
       value = new Date(value);
     }
 
-    var machineReadable = datetime.format(value, "%Y-%m-%dT%H:%M:%S");
-    // we can use %z formatter instead of formatOffset when
-    // https://github.com/joehewitt/datetime/pull/8 is merged
-    machineReadable += formatOffset(value);
+    value = moment(value);
+
+    var machineReadable = value.format('YYYY-MM-DDTHH:mm:ssZ');
 
     var props = {};
     for (var k in this.props) {
@@ -40,8 +28,7 @@ var Time = React.createClass({
     }
 
     if (this.props.relative || this.props.format) {
-      var formatter = this.props.relative ? datetime.formatAgo : datetime.format;
-      var humanReadable = formatter(value, this.props.format);
+      var humanReadable = this.props.relative ? value.fromNow() : value.format(this.props.format);
       props.dateTime = machineReadable;
       return React.DOM.time(props, humanReadable);
     } else {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "react-time",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "react component for rendering formatted timestamps",
   "main": "index.js",
   "dependencies": {
-    "datetime": "~0.0.3"
+    "moment": "~2.6.0"
   },
   "peerDependencies": {
     "react": "~0.10.0"

--- a/spec.js
+++ b/spec.js
@@ -12,23 +12,23 @@ describe('react-time', function() {
   });
 
   it('renders date in specified format', function() {
-    var c = Timestamp({value: date, format: "%Y%Y"});
+    var c = Timestamp({value: date, format: "YYYY YYYY"});
     var markup = React.renderComponentToString(c);
     assert(/datetime="1987\-05\-08T05:00:00[+-]\d\d:\d\d"/.test(markup));
-    assert(/19871987/.test(markup));
+    assert(/1987 1987/.test(markup));
   });
 
   it('renders date using relative format', function() {
     var c = Timestamp({value: date, relative: true});
     var markup = React.renderComponentToString(c);
     assert(/datetime="1987\-05\-08T05:00:00[+-]\d\d:\d\d"/.test(markup));
-    assert(/May  8th, 1987/.test(markup));
+    assert(/27 years ago/.test(markup));
   });
 
   it('transfers props down to DOM element', function() {
     var c = Timestamp({value: date, relative: true, className: 'className'});
     var markup = React.renderComponentToString(c);
-    assert(/May  8th, 1987/.test(markup));
+    assert(/27 years ago/.test(markup));
     assert(/class="className"/.test(markup));
   });
 });


### PR DESCRIPTION
Thanks for your work! I think moment.js is the de-facto standard in datetime handling and I would like to profit from the tested code base and huge number of localisations.

I also changed the tests because they would only work for people in `+05:00` (JavaScript automatically converts the value to your time zone).
