### PR TITLE
Fix React.PropTypes deprecation warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "mocha": "^2.4.5",
     "moment": "^2.8.3",
     "power-assert": "^1.3.1",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },

--- a/src/Time.js
+++ b/src/Time.js
@@ -3,7 +3,8 @@
  */
 
 import moment from 'moment';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class Time extends React.Component {
 


### PR DESCRIPTION
- Refactor code to use the new PropTypes object from 'prop-types' package recently extracted from React core