### PR TITLE
Allow React 16 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "extends": "prometheusresearch"
   },
   "peerDependencies": {
-    "react": ">=0.13.0 <16.0.0",
+    "react": ">=0.13.0 <17.0.0",
     "moment": "^2.8.3"
   },
   "devDependencies": {
@@ -20,8 +20,8 @@
     "moment": "^2.8.3",
     "power-assert": "^1.3.1",
     "prop-types": "^15.5.8",
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Note that some tests will fail due to
https://github.com/facebook/react/issues/11492

I think it should be fine to merge this anyway though, because the issue only seems to be with `ReactDOMServer.renderToString()`.